### PR TITLE
feat: support go tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 go.work
 bin/
 dist/
+.idea/

--- a/src/core/cache/cache.go
+++ b/src/core/cache/cache.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 	"strings"
 	"time"
@@ -271,8 +272,25 @@ func calculateCacheDirectoryFromInputData(opts plugins.GenerateOpts, ioFiles plu
 	return cacheHitDir, nil
 }
 
+func resolveExecutablePath(executable string) (string, error) {
+	// Support `go tool <exe>` by resolving the real tool path via `go tool -n`
+	const goToolPrefix = "go tool "
+	if strings.HasPrefix(executable, goToolPrefix) {
+		tool := strings.TrimPrefix(executable, goToolPrefix)
+		out, err := exec.Command("go", "tool", "-n", tool).Output()
+		if err != nil {
+			return "", fmt.Errorf("cannot resolve %q via 'go tool -n': %w", executable, err)
+		}
+
+		return strings.TrimSpace(string(out)), nil
+	}
+
+	// Use the executable path as-is by default
+	return fs.FindExecutablePath(executable)
+}
+
 func getExecutableDetails(ExecutablePath string) (string, error) {
-	ExecutablePath, err := fs.FindExecutablePath(ExecutablePath)
+	ExecutablePath, err := resolveExecutablePath(ExecutablePath)
 	if err != nil {
 		return "", err
 	}

--- a/src/core/cache/cache_test.go
+++ b/src/core/cache/cache_test.go
@@ -206,3 +206,10 @@ func TestExecutableFileInfo(t *testing.T) {
 	_, err = getExecutableDetails("bad_file")
 	assert.ErrorContains(t, err, "executable file not found in $PATH")
 }
+
+
+func TestExecutableFileInfoGoTool(t *testing.T) {
+	info, err := getExecutableDetails("go tool compile")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, info)
+}

--- a/src/core/generate/generate/generate.go
+++ b/src/core/generate/generate/generate.go
@@ -226,7 +226,8 @@ func (g *Generator) run() (ok bool) {
 			opts.ExecutablePath = words[0]
 		}
 
-		if !maybeParseGoRunCommand(&opts) {
+		// Normalize `go tool <exe>` first, then `go run <pkg>`; otherwise fall back to raw words.
+		if !maybeParseGoToolCommand(&opts) && !maybeParseGoRunCommand(&opts) {
 			opts.ExecutableName = filepath.Base(words[0])
 			opts.SanitizedArgs = words[1:]
 		}
@@ -479,6 +480,20 @@ func (g *Generator) exec(opts plugins.GenerateOpts) bool {
 		zap.S().Errorf("running %q: %s", opts.Command(), err)
 		return false
 	}
+	return true
+}
+
+func maybeParseGoToolCommand(opts *plugins.GenerateOpts) bool {
+	// Expect: go tool <name> [args...]
+	if len(opts.Words) < 3 {
+		return false
+	}
+	if opts.Words[0] != "go" || opts.Words[1] != "tool" {
+		return false
+	}
+	// Keep full logical identity for the executable name.
+	opts.ExecutableName = filepath.Base(opts.Words[2])
+	opts.SanitizedArgs = opts.Words[3:]
 	return true
 }
 

--- a/src/plugins/plugin.go
+++ b/src/plugins/plugin.go
@@ -12,9 +12,13 @@ type GenerateOpts struct {
 	Path string
 	// all the words being passed on the generate macro
 	Words []string
-	// name of the executable being run. if it is a go package, it will be the name of the cmd tool
+	// name of the executable being run.
+	// if it is a go package, it will be the name of the cmd tool
+	// if it is a go tool, it will be the name of the tool
 	ExecutableName string
-	// full path of the command being run. if it is a go package, this path will be an empty string
+	// full path of the command being run.
+	// if it is a go package, this path will be an empty string
+	// if it is a go tool, this path will be the full path to the tool binary
 	ExecutablePath string
 	// when this command is a "go run [pkg]" command, the name of the package being run
 	GoPackage string


### PR DESCRIPTION
# Description

Implemented support for [`Tool dependencies` feature](https://tip.golang.org/doc/modules/managing-dependencies#tools) which was introduced in Go 1.24. 

This feature allows Go projects to refer to `mockgen` (and other tools) like this:

```go
module github.com/example/project

go 1.24.0

tool (
    go.uber.org/mock/mockgen
)

require (
    go.uber.org/mock v0.6.0
)
```

_Why is this better?_

1. Automatic installation of `mockgen`
2. Version control the version of required `mockgen` 
3. Utilize [Go vendoring feature](https://go.dev/ref/mod#vendoring) for the `mockgen`

# Implementation

1. Use `maybeParseGoToolCommand` to check if `go tool <exec>` form is used
    Then Extract `ExecutableName`, to be used to detect the corresponding plugin
2. For cache purposes, extract the actual binary file path using `go tool -n <exec>`.

I have also added `.idea/` path to gitignore. This is a standard path for [GoLand IDE](https://www.jetbrains.com/go/).