### PR TITLE
fix: resolve go tool binaries via go tool -n fallback in noplugin cac…

### DIFF
--- a/src/core/cache/cache.go
+++ b/src/core/cache/cache.go
@@ -286,7 +286,16 @@ func resolveExecutablePath(executable string) (string, error) {
 	}
 
 	// Use the executable path as-is by default
-	return fs.FindExecutablePath(executable)
+	path, err := fs.FindExecutablePath(executable)
+	if err != nil {
+		out, toolErr := exec.Command("go", "tool", "-n", executable).CombinedOutput()
+		if toolErr == nil {
+			return strings.TrimSpace(string(out)), nil
+		}
+		return "", err
+	}
+
+	return path, nil
 }
 
 func getExecutableDetails(ExecutablePath string) (string, error) {

--- a/src/core/cache/cache_test.go
+++ b/src/core/cache/cache_test.go
@@ -240,3 +240,34 @@ func TestExecutableFileInfoGoTool(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, info)
 }
+
+func TestResolveExecutablePath_GoToolFallback(t *testing.T) {
+	resolved, err := resolveExecutablePath("compile")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resolved)
+	assert.FileExists(t, resolved)
+
+	expected, err := resolveExecutablePath("go tool compile")
+	assert.NoError(t, err)
+	assert.Equal(t, expected, resolved, "bare tool name should resolve to same path as 'go tool' prefix")
+}
+
+func TestGetExecutableDetails_GoToolBareName(t *testing.T) {
+	info, err := getExecutableDetails("compile")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, info)
+
+	infoWithPrefix, err := getExecutableDetails("go tool compile")
+	assert.NoError(t, err)
+	assert.Equal(t, infoWithPrefix, info, "bare tool name should produce same executable details as 'go tool' prefix")
+}
+
+func TestResolveExecutablePath_WithArgsFails(t *testing.T) {
+	_, err := resolveExecutablePath("compile -p main")
+	assert.Error(t, err, "should not resolve tool name containing arguments")
+}
+
+func TestResolveExecutablePath_NonExistent(t *testing.T) {
+	_, err := resolveExecutablePath("nonexistent-tool-xyz")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
…he path

When parseGoToolCommand extracts the executable name (e.g. "go-enum" from "go tool go-enum"), the noplugin cache path passes this bare name to resolveExecutablePath. The existing "go tool " prefix check never matches because the prefix was already stripped.

Add a fallback that tries "go tool -n <name>" when FindExecutablePath fails, allowing tools managed via go.mod tool dependencies to be properly resolved for cache key hashing.