### PR TITLE
fix: resolve go tool binaries correctly in noplugin cache path

### DIFF
--- a/src/core/cache/cache.go
+++ b/src/core/cache/cache.go
@@ -286,7 +286,16 @@ func resolveExecutablePath(executable string) (string, error) {
 	}
 
 	// Use the executable path as-is by default
-	return fs.FindExecutablePath(executable)
+	path, err := fs.FindExecutablePath(executable)
+	if err != nil {
+		out, toolErr := exec.Command("go", "tool", "-n", executable).CombinedOutput()
+		if toolErr == nil {
+			return strings.TrimSpace(string(out)), nil
+		}
+		return "", err
+	}
+
+	return path, nil
 }
 
 func getExecutableDetails(ExecutablePath string) (string, error) {

--- a/src/core/cache/cache.go
+++ b/src/core/cache/cache.go
@@ -242,7 +242,11 @@ func calculateCacheDirectoryFromInputData(opts plugins.GenerateOpts, ioFiles plu
 	}
 
 	if opts.GoPackage == "" {
-		execInfo, err := getExecutableDetails(opts.ExecutableName)
+		execName := opts.ExecutableName
+		if opts.IsGoTool {
+			execName = "go tool " + execName
+		}
+		execInfo, err := getExecutableDetails(execName)
 		if err != nil {
 			return "", fmt.Errorf("cannot get path for executable '%s': %s", opts.ExecutableName, err)
 		}
@@ -273,29 +277,17 @@ func calculateCacheDirectoryFromInputData(opts plugins.GenerateOpts, ioFiles plu
 }
 
 func resolveExecutablePath(executable string) (string, error) {
-	// Support `go tool <exe>` by resolving the real tool path via `go tool -n`
-	const goToolPrefix = "go tool "
-	if strings.HasPrefix(executable, goToolPrefix) {
-		tool := strings.TrimPrefix(executable, goToolPrefix)
+	if strings.HasPrefix(executable, "go tool ") {
+		tool := strings.TrimPrefix(executable, "go tool ")
 		out, err := exec.Command("go", "tool", "-n", tool).CombinedOutput()
 		if err != nil {
-			return "", fmt.Errorf("cannot resolve %q via 'go tool -n': %w (output: %s)", executable, err, string(out))
+			return "", fmt.Errorf("cannot resolve %q via 'go tool -n': %w (output: %s)", tool, err, string(out))
 		}
 
 		return strings.TrimSpace(string(out)), nil
 	}
 
-	// Use the executable path as-is by default
-	path, err := fs.FindExecutablePath(executable)
-	if err != nil {
-		out, toolErr := exec.Command("go", "tool", "-n", executable).CombinedOutput()
-		if toolErr == nil {
-			return strings.TrimSpace(string(out)), nil
-		}
-		return "", err
-	}
-
-	return path, nil
+	return fs.FindExecutablePath(executable)
 }
 
 func getExecutableDetails(ExecutablePath string) (string, error) {

--- a/src/core/cache/cache_test.go
+++ b/src/core/cache/cache_test.go
@@ -240,3 +240,34 @@ func TestExecutableFileInfoGoTool(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, info)
 }
+
+func TestResolveExecutablePath_GoToolFallback(t *testing.T) {
+	resolved, err := resolveExecutablePath("compile")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resolved)
+	assert.FileExists(t, resolved)
+
+	expected, err := resolveExecutablePath("go tool compile")
+	assert.NoError(t, err)
+	assert.Equal(t, expected, resolved, "bare tool name should resolve to same path as 'go tool' prefix")
+}
+
+func TestGetExecutableDetails_GoToolBareName(t *testing.T) {
+	info, err := getExecutableDetails("compile")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, info)
+
+	infoWithPrefix, err := getExecutableDetails("go tool compile")
+	assert.NoError(t, err)
+	assert.Equal(t, infoWithPrefix, info, "bare tool name should produce same executable details as 'go tool' prefix")
+}
+
+func TestResolveExecutablePath_WithArgsFails(t *testing.T) {
+	_, err := resolveExecutablePath("compile -p main")
+	assert.Error(t, err, "should not resolve tool name containing arguments")
+}
+
+func TestResolveExecutablePath_NonExistent(t *testing.T) {
+	_, err := resolveExecutablePath("nonexistent-tool-xyz")
+	assert.Error(t, err)
+}

--- a/src/core/cache/cache_test.go
+++ b/src/core/cache/cache_test.go
@@ -234,32 +234,23 @@ func TestExecutableFileInfo(t *testing.T) {
 	assert.ErrorContains(t, err, "executable file not found in $PATH")
 }
 
-
 func TestExecutableFileInfoGoTool(t *testing.T) {
 	info, err := getExecutableDetails("go tool compile")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, info)
 }
 
-func TestResolveExecutablePath_GoToolFallback(t *testing.T) {
-	resolved, err := resolveExecutablePath("compile")
+func TestResolveExecutablePath_GoToolPrefix(t *testing.T) {
+	resolved, err := resolveExecutablePath("go tool compile")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resolved)
 	assert.FileExists(t, resolved)
-
-	expected, err := resolveExecutablePath("go tool compile")
-	assert.NoError(t, err)
-	assert.Equal(t, expected, resolved, "bare tool name should resolve to same path as 'go tool' prefix")
 }
 
-func TestGetExecutableDetails_GoToolBareName(t *testing.T) {
-	info, err := getExecutableDetails("compile")
+func TestGetExecutableDetails_GoToolPrefix(t *testing.T) {
+	info, err := getExecutableDetails("go tool compile")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, info)
-
-	infoWithPrefix, err := getExecutableDetails("go tool compile")
-	assert.NoError(t, err)
-	assert.Equal(t, infoWithPrefix, info, "bare tool name should produce same executable details as 'go tool' prefix")
 }
 
 func TestResolveExecutablePath_WithArgsFails(t *testing.T) {

--- a/src/core/generate/generate/generate.go
+++ b/src/core/generate/generate/generate.go
@@ -289,6 +289,7 @@ func scanDirectives(absFile string, src []byte, pkg string) ([]directiveInfo, er
 			opts.SanitizedArgs = tempOpts.SanitizedArgs
 			opts.GoPackage = tempOpts.GoPackage
 			opts.GoPackageVersion = tempOpts.GoPackageVersion
+			opts.IsGoTool = tempOpts.IsGoTool
 		}
 
 		directives = append(directives, directiveInfo{
@@ -460,6 +461,7 @@ func parseGoToolCommand(opts *plugins.GenerateOpts) bool {
 	}
 	opts.ExecutableName = filepath.Base(opts.Words[2])
 	opts.SanitizedArgs = opts.Words[3:]
+	opts.IsGoTool = true
 	return true
 }
 

--- a/src/plugins/plugin.go
+++ b/src/plugins/plugin.go
@@ -24,6 +24,7 @@ type GenerateOpts struct {
 	GoPackage string
 	// when this command is a "go run [pkg]@version" command, the version specified on it (e.g. 1.2.3, latest). Empty string when not specified.
 	GoPackageVersion string
+	IsGoTool bool
 	// arguments being passed to the target executable.
 	// examples:
 	// [exec] -a -b arg -> ["-a", "-b", "arg"]


### PR DESCRIPTION
## Summary

When using `go tool <name>` directives (e.g. `//go:generate go tool stringer ...`), the noplugin cache path failed to resolve the tool binary because it attempted a direct PATH lookup on the tool name instead of using `go tool -n` to find the actual binary path.

This PR fixes the issue by:

- Adding an `IsGoTool` flag to `PluginOpts` so the cache layer knows when a directive uses `go tool`
- Using `go tool -n <name>` to resolve the real binary path when computing cache keys in the noplugin path
- Cleaning up `resolveExecutablePath` to avoid redundant prefix constants

## Test plan

- [x] Added unit tests for `resolveExecutablePath` with `go tool` prefix
- [x] Added unit test for `getExecutableDetails` with `go tool` prefix
- [x] Added negative tests for non-existent tools and args-in-name edge cases


🤖 Generated with [Claude Code](https://claude.com/claude-code)